### PR TITLE
Implement limit skip

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,34 +23,37 @@
   "devDependencies": {
     "@types/chai": "^3.4.34",
     "@types/lovefield": "^2.0.32",
-    "@types/node": "^6.0.51",
-    "@types/sinon": "^1.16.32",
+    "@types/node": "^6.0.58",
+    "@types/sinon": "^1.16.34",
     "@types/sinon-chai": "^2.7.27",
     "chai": "^3.5.0",
     "coveralls": "^2.11.15",
     "css-loader": "^0.26.1",
     "extract-text-webpack-plugin": "^1.0.1",
-    "html-webpack-plugin": "^2.24.1",
+    "html-webpack-plugin": "^2.26.0",
     "moment": "^2.17.1",
     "nyc": "^10.0.0",
     "raw-loader": "^0.5.1",
-    "sinon": "^1.17.6",
+    "rxjs": "^5.0.3",
+    "sinon": "^1.17.7",
     "sinon-chai": "^2.8.0",
     "source-map-loader": "^0.1.5",
     "style-loader": "^0.13.1",
-    "tman": "^1.6.3",
-    "ts-loader": "^1.2.2",
-    "ts-node": "^1.7.0",
-    "tslint": "^4.1.1",
-    "tslint-eslint-rules": "^3.2.0",
+    "tman": "^1.6.4",
+    "ts-loader": "^1.3.3",
+    "ts-node": "^2.0.0",
+    "tslint": "^4.3.1",
+    "tslint-eslint-rules": "^3.2.3",
     "tslint-loader": "^3.3.0",
     "typescript": "^2.1.4",
-    "webpack": "^1.13.3",
+    "webpack": "^1.14.0",
     "webpack-dev-server": "^1.16.2"
   },
   "dependencies": {
-    "lovefield": "^2.1.10",
-    "nesthydrationjs": "^1.0.0",
-    "rxjs": "^5.0.0-rc.5"
+    "lovefield": "^2.1.11",
+    "nesthydrationjs": "^1.0.0"
+  },
+  "peerDependencies": {
+    "rxjs": "^5.0.3"
   }
 }

--- a/src/storage/QueryToken.ts
+++ b/src/storage/QueryToken.ts
@@ -31,4 +31,9 @@ export class QueryToken <T> {
       })
     return new QueryToken(newMeta$)
   }
+
+  toString() {
+    return this.selectMeta$
+      .map(r => r.toString())
+  }
 }

--- a/src/storage/Selector.ts
+++ b/src/storage/Selector.ts
@@ -9,8 +9,6 @@ import {
 import { identity } from '../utils'
 import graphify from './Graphify'
 
-export type GraphMapper = (data: any) => any
-
 export interface TableShape {
   pk: {
     name: string,
@@ -24,7 +22,7 @@ export class Selector <T> {
     const originalToken = metaDatas[0]
     const fakeQuery = { toSql: identity }
     // 初始化一个空的 QuerySelector，然后在初始化以后替换它上面的属性和方法
-    const dist = new Selector<U>(originalToken.db, fakeQuery as any, identity)
+    const dist = new Selector<U>(originalToken.db, fakeQuery as any, { } as any)
     dist.change$ = Observable.from(metaDatas)
       .map(metas => metas.change$)
       .combineAll()
@@ -48,8 +46,8 @@ export class Selector <T> {
   constructor(
     public db: lf.Database,
     select: lf.query.Select,
-    private shape: TableShape | GraphMapper,
     public predicate?: lf.Predicate
+    private shape: TableShape,
   ) {
     this.select = select.toSql()
     this.query = predicate ? select.where(predicate) : select
@@ -100,11 +98,6 @@ export class Selector <T> {
     return this.query
       .exec()
       .then((rows: any[]) => {
-        // manually provided mapper function
-        if (typeof this.shape === 'function') {
-          return this.shape(rows)
-        }
-
         const result = graphify<T>(rows, this.shape.definition)
         const col = this.shape.pk.name
 

--- a/src/storage/Selector.ts
+++ b/src/storage/Selector.ts
@@ -114,7 +114,7 @@ export class Selector <T> {
 
   private removeKey(data: any[], key: string) {
     data.forEach((entity) => {
-        delete entity[key]
+      delete entity[key]
     })
 
     return data

--- a/test/specs/storage/Database.public.spec.ts
+++ b/test/specs/storage/Database.public.spec.ts
@@ -325,8 +325,10 @@ export default describe('Database public Method', () => {
         let result: any[]
         try {
           result = yield database.get<TaskSchema>('Task', <any>{
-            get where() {
-              throw new TypeError('error occured when build execute where clause function')
+            where: {
+              get whatever() {
+                throw new TypeError('error occured when build execute where clause function')
+              }
             }
           }).values()
         } catch (e) {
@@ -346,6 +348,27 @@ export default describe('Database public Method', () => {
         }).values()
 
         expect(_id).to.equal(task._id)
+      })
+
+      it('should ok with skip and limit', function* () {
+        yield database.delete('Task')
+
+        const tasks = taskGenerator(100)
+        yield database.insert('Task', tasks)
+
+        const result = yield database.get('Task', {
+          limit: 10,
+          skip: 20
+        })
+          .values()
+
+        yield Observable.from(tasks)
+          .skip(20)
+          .take(10)
+          .toArray()
+          .do(r => {
+            expect(r).to.deep.equal(result)
+          })
       })
     })
 

--- a/test/specs/storage/QueryToken.spec.ts
+++ b/test/specs/storage/QueryToken.spec.ts
@@ -68,6 +68,11 @@ export default describe('QueryToken test', () => {
     })
   })
 
+  it('QueryToken.prototype.toString', function* () {
+    const sql = yield queryToken.toString()
+    expect(sql).to.equal(mockSelectMeta.toString())
+  })
+
   describe('QueryToken.prototype.combine', () => {
     let tasks2: TaskSchema[]
     let mockSelectMeta2: MockSelectMeta<TaskSchema>

--- a/test/specs/storage/Selector.spec.ts
+++ b/test/specs/storage/Selector.spec.ts
@@ -125,6 +125,19 @@ export default describe('SelectMeta test', () => {
     }
   })
 
+  it('should get sql string by toString method', () => {
+    const selector = new Selector(db,
+      db.select().from(table),
+      tableShape,
+      new PredicateProvider(table, { time: { $gt: 50 } }),
+      20, 20
+    )
+
+    const sql = selector.toString()
+
+    expect(sql).to.equal('SELECT * FROM TestSelectMetadata;')
+  })
+
   describe('SelectMeta.prototype.changes', () => {
     it('observe should ok', done => {
       const selector = new Selector(db, db.select().from(table), (values: any[]) => {

--- a/test/utils/MockSelectMeta.ts
+++ b/test/utils/MockSelectMeta.ts
@@ -59,6 +59,10 @@ export default class MockSelector<T> {
 
   }
 
+  toString() {
+    return `MockSelector SQL`
+  }
+
   private notify() {
     this.subject.next(this.datas)
   }


### PR DESCRIPTION
### Description:
实现 limit 和 skip

直接在 leftOuterJoin 的 Select 上使用 lovefield 提供的 skip 和 limit 是有问题的，会导致取出来的数据 fold 之后不满足 skip limit 条件。
所以先在需要查的主表中先 skip & limit 拿到范围内的 pks (Primary Keys)，再将这个 pks 作为 predicate 构建新的 leftOuterJoin Select。

### Related issue (if exists):
