### PR TITLE
fix(type): let utils.forEach return void

### DIFF
--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -9,7 +9,7 @@ export function forEach<T> (
 
 export function forEach (target: any, eachFunc: (val: any, key: any) => void, inverse?: boolean): void
 
-export function forEach (target: any, eachFunc: (val: any, key: any) => any, inverse?: boolean) {
+export function forEach (target: any, eachFunc: (val: any, key: any) => any, inverse?: boolean): void {
   let length: number
   if (target instanceof Array) {
     length = target.length
@@ -41,7 +41,6 @@ export function forEach (target: any, eachFunc: (val: any, key: any) => any, inv
       }
     }
   }
-  return target
 }
 
 export const clone = <T>(origin: T): T | null => {


### PR DESCRIPTION
...so that readers of the function's signature will be clear
about the purpose of using utils.forEach: trigger side-effects
intead of generating a value.

Also, the new returning type resembles the returning type of
Array.prototype.forEach.

Note: the previous returning value from utils.forEach was never
utilized in our code, so this change shouldn't effect any of the
current callers' behaviors.