### PR TITLE
style: general code refactoring

### DIFF
--- a/src/storage/Database.ts
+++ b/src/storage/Database.ts
@@ -189,6 +189,8 @@ export class Database {
     }
 
     let hasPK = false
+    // src: schemaMetaData; dest: hasPK;
+    // short-curcuiting at the first meta that has primaryKey
     forEach(schemaMetaData, meta => {
       if (meta.primaryKey) {
         hasPK = true
@@ -397,6 +399,8 @@ export class Database {
           }
         }
 
+        // source: patch; dest: updateQuery;
+        // no short-curcuiting
         forEach(patch, (val, key) => {
           const column = table[key]
           const virtualMeta = selectMetadata.virtualMeta.get(key)
@@ -537,6 +541,8 @@ export class Database {
     const virtualMeta = new Map<string, VirtualMetadata>()
     const mapper = new Map<string, Function>()
 
+    // src: schemaMetaData; dest: uniques, indexes, primaryKey, nullable, fields, vitualMeta, mapper
+    // no short-curcuiting
     forEach(schemaMetaData, (def, key) => {
       if (!def.virtual) {
         tableBuilder = this.addRow(tableBuilder, key, def.type as RDBType, nullable, def)

--- a/src/storage/Database.ts
+++ b/src/storage/Database.ts
@@ -872,11 +872,9 @@ export class Database {
       definition[key] = Database.reviseAssocDefinition(assocDesc.association, ret.definition)
 
       const predicate = Database.unwrapPredicate(ret.table, currentTable, assocDesc.where)
-      if (predicate) {
-        joinInfo.push({ table: ret.table, predicate })
-      }
-
-      joinInfo = joinInfo.concat(ret.joinInfo)
+      const joinLink = predicate ?
+        [{ table: ret.table, predicate }, ...ret.joinInfo] : ret.joinInfo
+      joinInfo = joinInfo.concat(joinLink)
     }
 
     fieldTree.forEach(field => {

--- a/src/storage/Database.ts
+++ b/src/storage/Database.ts
@@ -586,7 +586,7 @@ export class Database {
       }
 
       if (!def['isHidden']) {
-        return null
+        return
       }
 
       // create a hidden column in table and make compare datetime easier

--- a/test/specs/storage/Database.public.spec.ts
+++ b/test/specs/storage/Database.public.spec.ts
@@ -338,7 +338,7 @@ export default describe('Database public Method', () => {
           throw new TypeError('Invalid code path reached.')
         }
 
-        expect(result.length).to.greaterThan(0)
+        expect(result).to.have.length.above(0)
       })
 
       it('should get value when both pk and whereClause were specified', function* () {
@@ -620,7 +620,7 @@ export default describe('Database public Method', () => {
 
       const result = yield database.get<TaskSchema>('Task').values()
       if (result.length) {
-        expect(result.length).to.equal(count)
+        expect(result).to.have.lengthOf(count)
       } else {
         expect(result).deep.equal([])
       }
@@ -694,7 +694,7 @@ export default describe('Database public Method', () => {
 
       const rets = yield database.get<TaskSchema>('Task').values()
 
-      expect(rets.length).to.equal(1)
+      expect(rets).to.have.lengthOf(1)
       expect(rets[rets.length - 1]).deep.equal(task)
     })
 

--- a/test/specs/storage/PredicateProvider.spec.ts
+++ b/test/specs/storage/PredicateProvider.spec.ts
@@ -62,7 +62,7 @@ export default describe('PredicateProvider test', () => {
         .where(predicate)
         .exec()
 
-      expect(result.length).to.equal(1)
+      expect(result).to.have.lengthOf(1)
       expect(result[0]['time1']).to.equal(20)
     })
 
@@ -78,7 +78,7 @@ export default describe('PredicateProvider test', () => {
         .where(predicate)
         .exec()
 
-      expect(result.length).to.equal(dataLength - 1)
+      expect(result).to.have.lengthOf(dataLength - 1)
 
       result.forEach((r: any) => expect(r['time1'] === 20).to.be.false)
     })
@@ -95,7 +95,7 @@ export default describe('PredicateProvider test', () => {
         .where(predicate)
         .exec()
 
-      expect(result.length).to.equal(20)
+      expect(result).to.have.lengthOf(20)
       result.forEach((r: any) => expect(r['time1'] < 20).to.be.true)
     })
 
@@ -111,7 +111,7 @@ export default describe('PredicateProvider test', () => {
         .where(predicate)
         .exec()
 
-      expect(result.length).to.equal(20)
+      expect(result).to.have.lengthOf(20)
       result.forEach((r: any) => expect(r['time1'] <= 19).to.be.true)
     })
 
@@ -127,7 +127,7 @@ export default describe('PredicateProvider test', () => {
         .where(predicate)
         .exec()
 
-      expect(result.length).to.equal(dataLength - 20)
+      expect(result).to.have.lengthOf(dataLength - 20)
       result.forEach((r: any) => expect(r['time2'] > 20).to.be.true)
     })
 
@@ -143,7 +143,7 @@ export default describe('PredicateProvider test', () => {
         .where(predicate)
         .exec()
 
-      expect(result.length).to.equal(dataLength - 20)
+      expect(result).to.have.lengthOf(dataLength - 20)
       result.forEach((r: any) => expect(r['time2'] >= 21).to.be.true)
     })
 
@@ -160,7 +160,7 @@ export default describe('PredicateProvider test', () => {
         .where(predicate)
         .exec()
 
-      expect(result.length).to.equal(10)
+      expect(result).to.have.lengthOf(10)
       result.forEach((r: any) => expect(regExp.test(r['name'])).to.be.true)
     })
 
@@ -178,7 +178,7 @@ export default describe('PredicateProvider test', () => {
         .exec()
 
       // 上一个测试中结果长度是 10
-      expect(result.length).to.equal(dataLength - 10)
+      expect(result).to.have.lengthOf(dataLength - 10)
       result.forEach((r: any) => expect(regExp.test(r['name'])).to.be.false)
     })
 
@@ -194,7 +194,7 @@ export default describe('PredicateProvider test', () => {
         .where(predicate)
         .exec()
 
-      expect(result.length).to.equal(20)
+      expect(result).to.have.lengthOf(20)
       result.forEach((r: any) => expect(r['time1'] > 0 && r['time1'] <= 20).to.be.true)
     })
 
@@ -210,7 +210,7 @@ export default describe('PredicateProvider test', () => {
         .where(predicate)
         .exec()
 
-      expect(result.length).to.equal(3)
+      expect(result).to.have.lengthOf(3)
       result.forEach((r: any) => {
         expect(r.times.match(/times: 10\b/)).to.not.be.null
       })
@@ -229,7 +229,7 @@ export default describe('PredicateProvider test', () => {
         .where(predicate)
         .exec()
 
-      expect(result.length).to.equal(3)
+      expect(result).to.have.lengthOf(3)
       result.forEach((r: any) => expect(seed.indexOf(r['time1']) !== -1).to.be.true)
     })
 
@@ -245,7 +245,7 @@ export default describe('PredicateProvider test', () => {
         .where(predicate)
         .exec()
 
-      expect(result.length).to.equal(700)
+      expect(result).to.have.lengthOf(700)
       result.forEach((r: any) => expect(r['nullable']).to.be.null)
     })
 
@@ -261,7 +261,7 @@ export default describe('PredicateProvider test', () => {
         .where(predicate)
         .exec()
 
-      expect(result.length).to.equal(300)
+      expect(result).to.have.lengthOf(300)
       result.forEach((r: any) => expect(r['nullable']).to.not.be.null)
     })
 
@@ -277,7 +277,7 @@ export default describe('PredicateProvider test', () => {
         .where(predicate)
         .exec()
 
-      expect(result.length).to.equal(dataLength - 1)
+      expect(result).to.have.lengthOf(dataLength - 1)
     })
 
     it('$and should ok', function* () {
@@ -295,7 +295,7 @@ export default describe('PredicateProvider test', () => {
         .where(predicate)
         .exec()
 
-      expect(result.length).to.equal(150)
+      expect(result).to.have.lengthOf(150)
       result.forEach((r: any) => expect(r['time1'] >= 50 && r['time1'] < 200).to.be.true)
     })
 
@@ -314,7 +314,7 @@ export default describe('PredicateProvider test', () => {
         .where(predicate)
         .exec()
 
-      expect(result.length).to.equal(100)
+      expect(result).to.have.lengthOf(100)
       result.forEach((r: any) => expect(r['time1'] >= dataLength - 50 || r['time1'] < 50).to.be.true)
     })
 
@@ -343,7 +343,7 @@ export default describe('PredicateProvider test', () => {
         .where(predicate)
         .exec()
 
-      expect(result.length).to.equal(5)
+      expect(result).to.have.lengthOf(5)
 
       result.forEach((r: any) => {
         const pred1 = r['time1'] >= dataLength - 50 || r['time1'] < 50

--- a/test/specs/storage/Selector.spec.ts
+++ b/test/specs/storage/Selector.spec.ts
@@ -115,7 +115,7 @@ export default describe('SelectMeta test', () => {
 
     const results = yield selector.values()
 
-    expect(results.length).to.equal(1000 - 50)
+    expect(results).to.have.lengthOf(1000 - 50)
     results.forEach((ret: any) => {
       expect(ret.time >= 50).to.equals(true)
     })
@@ -145,7 +145,7 @@ export default describe('SelectMeta test', () => {
     )
     const result = yield selector.values()
 
-    expect(result.length).to.equal(20)
+    expect(result).to.have.lengthOf(20)
 
     result.forEach((r: any) => {
       expect(r.time).to.greaterThan(70)
@@ -179,7 +179,7 @@ export default describe('SelectMeta test', () => {
 
     yield selector.values()
       .do(result => {
-        expect(result.length).to.equal(950)
+        expect(result).to.have.lengthOf(950)
         const expectResult = storeData.filter(r => r.time >= 50)
           .sort((a, b) => {
             const higherPriority = Math.sign(a.priority - b.priority)
@@ -474,7 +474,7 @@ export default describe('SelectMeta test', () => {
 
       yield signal.take(1)
         .do(r => {
-          expect(r.length).to.equal(20)
+          expect(r).to.have.lengthOf(20)
           r.forEach((v: any) => {
             expect(v.time).to.gt(80)
             expect(v.time).to.lte(100)
@@ -503,7 +503,7 @@ export default describe('SelectMeta test', () => {
 
       yield signal.take(1)
         .do(r => {
-          expect(r.length).to.equal(9)
+          expect(r).to.have.lengthOf(9)
           r.forEach((v: any) => {
             expect(v.time).to.gt(990)
             expect(v.time).to.lt(1000)
@@ -562,7 +562,7 @@ export default describe('SelectMeta test', () => {
     it('result metadata should combine all results', done => {
       dist.values()
         .subscribe(r => {
-          expect(r.length).to.equal(200)
+          expect(r).to.have.lengthOf(200)
           done()
         })
     })
@@ -570,7 +570,7 @@ export default describe('SelectMeta test', () => {
     it('result should be combined', function* () {
       const result = yield dist.values()
       const count = 200
-      expect(result.length).is.equals(count)
+      expect(result).to.have.lengthOf(count)
       result.forEach((r: any, index: number) => {
         expect(r).to.deep.equal(storeData[index])
       })
@@ -640,7 +640,7 @@ export default describe('SelectMeta test', () => {
 
       yield signal.take(1)
         .do(r => {
-          expect(r.length).to.equal(40)
+          expect(r).to.have.lengthOf(40)
           r.forEach(v => expect(v['time']).not.equal(81))
           Observable.from(r)
             .skip(19)
@@ -655,7 +655,7 @@ export default describe('SelectMeta test', () => {
 
       yield signal.take(1)
         .do(r => {
-          expect(r.length).to.equal(40)
+          expect(r).to.have.lengthOf(40)
           r.forEach(v => expect(v['time']).not.equal(135))
           Observable.from(r)
             .last()

--- a/test/specs/utils.spec.ts
+++ b/test/specs/utils.spec.ts
@@ -64,9 +64,7 @@ export default describe('utils test', () => {
     forEach(arr, (val) => {
       result.push(val)
     }, true)
-    for (let i = 0; i < arr.length ; i ++) {
-      expect(result[5 - i]).to.equal(arr[i])
-    }
+    expect(result).to.eql(arr.slice(0).reverse())
   })
 
   it('inverse forEach break should ok', () => {

--- a/test/specs/utils.spec.ts
+++ b/test/specs/utils.spec.ts
@@ -48,7 +48,7 @@ export default describe('utils test', () => {
       }
       return dest.push(ele)
     })
-    expect(dest.length).to.equal(2)
+    expect(dest).to.have.lengthOf(2)
   })
 
   it('inverse forEach should ok', () => {
@@ -76,7 +76,7 @@ export default describe('utils test', () => {
       }
       return dest.push(ele)
     }, true)
-    expect(dest.length).to.equal(3)
+    expect(dest).to.have.lengthOf(3)
   })
 
   it('forEach object should ok', () => {


### PR DESCRIPTION
- 用 	chai.expect(arr).to.have.lengthOf(n) 替代 chai.expect(arr.length).to.equal(n)；
- 将 Database.ts 下的 traverseFields 函数中的部分重复代码移至一个内部函数里。