### PR TITLE
fix(selector): fix wrong concat restriction

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "license": "MIT",
   "devDependencies": {
     "@types/chai": "^3.4.34",
-    "@types/node": "^6.0.58",
+    "@types/node": "^7.0.5",
     "@types/sinon": "^1.16.34",
     "@types/sinon-chai": "^2.7.27",
     "awesome-typescript-loader": "^3.0.2",
@@ -52,7 +52,7 @@
     "tslint": "^4.3.1",
     "tslint-eslint-rules": "^3.2.3",
     "tslint-loader": "^3.3.0",
-    "typescript": "^2.1.5",
+    "typescript": "^2.2.1",
     "webpack": "^2.2.1",
     "webpack-dev-server": "^2.3.0"
   },

--- a/src/storage/QueryToken.ts
+++ b/src/storage/QueryToken.ts
@@ -10,7 +10,7 @@ export class QueryToken<T> {
   }
 
   map<K>(fn: (val: T, index?: number) => K) {
-    return new QueryToken<K>(this.selectMeta$.do((selector: Selector<any>) => {
+    return new QueryToken<K>((this.selectMeta$ as Observable<Selector<any>>).do((selector) => {
       const previousValues = selector.values
       const previousChange$ = selector.change$
 

--- a/src/storage/Selector.ts
+++ b/src/storage/Selector.ts
@@ -204,7 +204,6 @@ export class Selector <T> {
 
   concat(... selectMetas: Selector<T>[]): Selector<T> {
     const equal = selectMetas.every(m =>
-      m.limit === this.limit &&
       m.select === this.select &&
       m.predicateProvider.toString() === this.predicateProvider.toString()
     )

--- a/test/specs/storage/Selector.spec.ts
+++ b/test/specs/storage/Selector.spec.ts
@@ -837,19 +837,18 @@ export default describe('Selector test', () => {
         db.select().from(table),
         tableShape,
         new PredicateProvider(table, { time: { $gte: 50 } }),
-        20, 0
+        10, 0
       )
       const selector6 = new Selector(db,
         db.select().from(table),
         tableShape,
         new PredicateProvider(table, { time: { $gte: 50 } }),
-        21, 20
+        20, 11
       )
 
       const fn = () => selector5.concat(selector6)
-      const error = TOKEN_CONCAT_ERR()
 
-      expect(fn).to.throw(error.message)
+      expect(fn).to.throw()
     })
 
     it('concat two selector predicate not match should throw', () => {


### PR DESCRIPTION
#### Description
`QueryToken#concat` 不应该有 `limit` 相等这一限制。
在实际应用场景中只需要保证 `skips.every((s, i) => s === limit * i)` 即可
