### PR TITLE
fix(storage): 修正 Database 上 get 方法对不含 where 字段 query 的处理

### DIFF
--- a/src/storage/Database.ts
+++ b/src/storage/Database.ts
@@ -445,7 +445,7 @@ export class Database {
         mainTable: table!
       }
       const { limit, skip } = clause
-      const provider = new PredicateProvider(table!, clause.where!)
+      const provider = clause.where ? new PredicateProvider(table!, clause.where) : null
 
       return new Selector<T>(db, query, matcher, provider, limit, skip, orderDesc)
     })

--- a/test/specs/storage/Database.public.spec.ts
+++ b/test/specs/storage/Database.public.spec.ts
@@ -1,4 +1,4 @@
-import { Observable } from 'rxjs/Observable'
+import { Observable, Scheduler } from 'rxjs'
 import * as moment from 'moment'
 import { describe, it, beforeEach, afterEach } from 'tman'
 import { expect, assert, use } from 'chai'
@@ -10,7 +10,7 @@ import { TestFixture2 } from '../../schemas/Test'
 import { scenarioGen, programGen, postGen, taskGen, subtaskGen } from '../../utils/generators'
 import { RDBType, DataStoreType, Database, clone, forEach, JoinMode } from '../../index'
 import { TaskSchema, ProjectSchema, PostSchema, ModuleSchema, ProgramSchema, SubtaskSchema } from '../../index'
-import { InvalidQuery, NonExistentTable, InvalidType, PrimaryKeyNotProvided, NotConnected } from '../../index'
+import { InvalidQuery, NonExistentTable, InvalidType, PrimaryKeyNotProvided, NotConnected, Selector } from '../../index'
 
 use(SinonChai)
 
@@ -249,6 +249,15 @@ export default describe('Database Testcase: ', () => {
 
       expect(_id).to.equal(target._id)
       expect(_projectId).to.equal(target._projectId)
+    })
+
+    it('on query without `where`, should result in QueryToken whose Selector does not have predicateProvider', function* () {
+      yield database.get<TaskSchema>('Task', {}).selector$
+        .subscribeOn(Scheduler.async)
+        .do((x: Selector<TaskSchema>) => {
+          console.info(x.toString())
+          expect(x.predicateProvider).to.be.null
+        })
     })
 
     it('should get single record successfully', function* () {

--- a/test/specs/storage/modules/Selector.spec.ts
+++ b/test/specs/storage/modules/Selector.spec.ts
@@ -153,7 +153,7 @@ export default describe('Selector test', () => {
 
     const sql = selector.toString()
 
-    expect(sql).to.equal('SELECT * FROM TestSelectMetadata WHERE ((TestSelectMetadata.time > 50));')
+    expect(sql).to.equal('SELECT * FROM TestSelectMetadata WHERE (TestSelectMetadata.time > 50);')
   })
 
   it('should get correct results with orderBy', function* () {
@@ -920,6 +920,26 @@ export default describe('Selector test', () => {
       yield changes$.take(1)
         .subscribeOn(Scheduler.async)
         .do(r => expect(r[75].name).equal(update3))
+    })
+
+    it('concat selector should ok when neither selectors have predicateProvider', function* () {
+      selector1 = new Selector(db,
+        db.select().from(table),
+        tableShape,
+        null,
+        20, 0
+      )
+      selector2 = new Selector(db,
+        db.select().from(table),
+        tableShape,
+        null,
+        20, 20
+      )
+      const result = yield selector1.concat(selector2).values()
+      expect(result).to.have.lengthOf(40)
+      result.forEach((r: any, index: number) => {
+        expect(r).to.deep.equal(storeData[index])
+      })
     })
 
     it('concat selector should ok with OrderDescription', function* () {


### PR DESCRIPTION
...并在 concat selector 时进行的查询信息等价比较上，妥善处理
predicateProvider 为空而导致没有 toString 方法可调用，throw 的情况。

...resolves #93